### PR TITLE
Correction de l'erreur CSFR

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -36,6 +36,8 @@ HOST_URL = os.getenv("HOST_URL", "127.0.0.1, localhost")
 
 ALLOWED_HOSTS = HOST_URL.replace(" ", "").split(",")
 
+CSRF_TRUSTED_ORIGINS = [f"https://{ host }" for host in ALLOWED_HOSTS]
+
 INTERNAL_IPS = [
     "127.0.0.1",
 ]


### PR DESCRIPTION
Ajout des `ALLOWED_HOSTS` dans les `CSRF_TRUSTED_ORIGINS` pour éviter cette erreur :
![image](https://github.com/betagouv/CNR_orga/assets/17601807/cf170472-dcb8-4462-b662-74d614aef78d)
