### PR TITLE
Corrections ergonomiques du formulaire d'ajout de contribution

### DIFF
--- a/event/views/organizer.py
+++ b/event/views/organizer.py
@@ -95,6 +95,11 @@ class ContributionCreateView(OrganizerMixin, FormView):
     template_name = "event/organizer/contribution_edit.html"
     form_class = ContributionForm
 
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["public"] = True
+        return initial
+
     def get_event(self):
         return get_object_or_404(Event, pk=self.kwargs.get("event_pk"), owner=self.request.user)
 

--- a/templates/event/organizer/contribution_edit.html
+++ b/templates/event/organizer/contribution_edit.html
@@ -31,12 +31,6 @@
                                     {% dsfr_form_field form.status %}
                                 </div>
                             </fieldset>
-                            <div class="form-actions mb-3">
-                                <input type="submit" class="fr-btn" name="submit" value="Enregistrer" />
-                                {% if not object %}
-                                    <input type="submit" class="fr-btn fr-btn--secondary" name="submitandadd" value="Enregistrer et ajouter une nouvelle contribution" />
-                                {% endif %}
-                            </div>
                         </div>
                         <div class="fr-col-12 fr-col-md-6 fr-pr-md-6w">
                             <fieldset class="fr-fieldset">
@@ -59,6 +53,14 @@
 
                                 </div>
                             </fieldset>
+                        </div>
+                        <div class="fr-col-12">
+                            <div class="form-actions mb-3">
+                                <input type="submit" class="fr-btn fr-mb-2v" name="submit" value="Enregistrer" />
+                                {% if not object %}
+                                    <input type="submit" class="fr-btn fr-btn--secondary" name="submitandadd" value="Enregistrer et ajouter une nouvelle contribution" />
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
Le formulaire s'ouvre désormais avec l'option "publique" cochée par défaut.
Les boutons apparaissent désormais tout en bas du formulaire sur petit écran.

![image](https://github.com/betagouv/CNR_orga/assets/17601807/799ce252-fdf7-4217-a706-b48bdd89f2db)
