### PR TITLE
Gestion des concertations à plusieurs

### DIFF
--- a/event/factories.py
+++ b/event/factories.py
@@ -31,6 +31,15 @@ class EventFactory(factory.django.DjangoModelFactory):
     booking_online = True
     participant_help = True
 
+    @factory.post_generation
+    def organizers(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        self.organizers.add(self.owner)
+        if extracted:
+            self.organizers.add(*extracted)
+
     class Params:
         upcoming = factory.Trait(
             start=factory.fuzzy.FuzzyDateTime(

--- a/event/migrations/0012_fill_first_organizer.py
+++ b/event/migrations/0012_fill_first_organizer.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def _fill_first_organizer(apps, schema_editor):  # pylint: disable=unused-argument
+    Event = apps.get_model("event", "Event")
+    events = Event.objects.all()
+    for event in events:
+        event.organizers.add(event.owner)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("event", "0011_event_synthesis"),
+    ]
+
+    operations = [
+        migrations.RunPython(_fill_first_organizer, migrations.RunPython.noop, elidable=True),
+    ]

--- a/event/urls.py
+++ b/event/urls.py
@@ -6,6 +6,7 @@ from event.views.organizer import (
     OrganizerDashboardView,
     OrganizerEventCreateView,
     OrganizerEventDetailView,
+    OrganizerEventOrganizerAddView,
     OrganizerEventUpdateView,
     OrganizerRegistrationAcceptView,
     OrganizerRegistrationDeclineView,
@@ -45,6 +46,11 @@ urlpatterns = [
         "organizer/contribution/<int:pk>/update",
         ContributionUpdateView.as_view(),
         name="event_organizer_contribution_update",
+    ),
+    path(
+        "organizer/event/<int:event_pk>/add-organizer/",
+        OrganizerEventOrganizerAddView.as_view(),
+        name="event_organizer_event_add_organizer",
     ),
     # Participant
     path("list", EventListView.as_view(), name="event_list"),

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,6 +28,19 @@
         {% include "blocks/header.html" %}
         {% dsfr_theme_modale %}
         <main id="content" role="main">
+            {% if messages %}
+                <div class="fr-container">
+                    <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
+                        <div class="fr-col-12 fr-pt-12v">
+                            {% for message in messages %}
+                                <div class="fr-alert{% if message.tags %} fr-alert--{{ message.tags }}{% endif %}">
+                                    <p>{{ message }}</p>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
             {% block content %}{% endblock content %}
         </main>
         {% include "blocks/footer.html" %}

--- a/templates/event/organizer/event_add_organizer.html
+++ b/templates/event/organizer/event_add_organizer.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% load dsfr_tags %}
+{% block content %}
+    <div class="fr-container fr-mb-md-14v">
+        <div class="fr-grid-row fr-grid-row-gutters fr-grid-row--center">
+            <div id="contenu" class="fr-col-6 fr-py-12v">
+                <form method="post" enctype="multipart/form-data">{% csrf_token %}
+                    <fieldset class="fr-fieldset">
+                        <legend class="fr-fieldset__legend">
+                            <h2>Ajouter un organisateur à votre concertation CNR</h2>
+                        </legend>
+                        {% if form.non_field_errors %}
+                            {% for error in form.non_field_errors %}
+                                <div class="alert alert-danger" role="alert">
+                                    <p class="mb-0">
+                                        {{ error }}
+                                    </p>
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+                        <div class="fr-fieldset__element">
+                            {% dsfr_form %}
+                        </div>
+                    </fieldset>
+                    <div class="form-actions mb-3">
+                        <a href="{% url 'event_organizer_event_detail' event.pk %}" class="fr-btn fr-btn--secondary">Retour</a>
+                        <input type="submit" class="fr-btn" value="Ajouter" />
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/event/organizer/event_detail.html
+++ b/templates/event/organizer/event_detail.html
@@ -23,6 +23,9 @@
                 <li role="presentation">
                   <button id="tabpanel-406" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-406-panel">Contributions ({{ contributions.count }})</button>
                 </li>
+                <li role="presentation">
+                  <button id="tabpanel-407" class="fr-tabs__tab fr-icon-checkbox-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-407-panel">Organisateurs ({{ event.organizers.count }})</button>
+                </li>
               </ul>
               <div id="tabpanel-404-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabindex="0">
                 <div class="fr-grid-row fr-grid-row-gutters fr-mb-5w">
@@ -156,6 +159,47 @@
                       </div>
                     </div>
                   {% endfor %}
+                </div>
+              </div>
+              <div id="tabpanel-407-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-407" tabindex="0">
+                <div class="fr-grid-row fr-grid-row--gutters fr-mb-1w">
+                  <div class="fr-col-md-6 fr-col-12">
+                    <h2>Liste des organisateurs</h2>
+                  </div>
+                  {% if user == event.owner %}
+                    <div class="fr-col-md-6 fr-col-12">
+                      <ul class="fr-btns-group fr-btns-group--inline-md fr-btns-group--right">
+                        <li>
+                          <a href="{% url 'event_organizer_event_add_organizer' event.pk %}" class="fr-btn" target="_self">Ajouter un organisateur</a>
+                        </li>
+                      </ul>
+                    </div>
+                  {% endif %}
+                  <div class="fr-col-12">
+                    <div class="fr-table fr-table--layout-fixed">
+                      <table>
+                        <caption></caption>
+                        <thead>
+                          <tr>
+                            <th scope="col">Prénom</th>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Email</th>
+                            <th scope="col"></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {% for organizer in event.organizers.all %}
+                            <tr>
+                              <td>{{ organizer.first_name }}</td>
+                              <td>{{ organizer.last_name }}</td>
+                              <td>{{ organizer.email }}</td>
+                              <td>{% if organizer == event.owner %}Propriétaire{% endif %}</td>
+                            </tr>
+                          {% endfor %}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Afin de pouvoir gérer les concertations à plusieurs utilisateur.ice.s, il faut d'une part, changer la façon de vérifier les droits sur les différentes vues. Pour cela, la vérification se fait sur la liste des organisateurs et non plus sur le propriétaire de la concertation.
D'autre part, il faut permettre aux organisateurs propriétaires de leurs concertations d'autoriser d'autres organisateurs à gérer leurs concertations.

# Formulaire d'ajout d'un organisateur

![screenshot-localhost_8000-2023 06 07-16_16_26](https://github.com/betagouv/CNR_orga/assets/17601807/867775c6-5a4b-4a4b-bb68-8dbfa017cb7c)

# Liste des organisateurs de la concertation

![screenshot-localhost_8000-2023 06 07-16_15_23](https://github.com/betagouv/CNR_orga/assets/17601807/095f0c8c-b051-4a55-a74e-82ecf0af8205)

À noter qu'un organisateur doit être inscrit et identifié comme organisateur avant de pouvoir être ajouté à une concertation.