### PR TITLE
Possibilité d'exporter les participants d'une concertation au format csv

### DIFF
--- a/event/tests/test_views_organizer.py
+++ b/event/tests/test_views_organizer.py
@@ -184,6 +184,32 @@ class EventUpdateViewTest(TestCase):
         self.assertEqual(event_after.subject, other_event.subject)
 
 
+class EventParticipantsExportViewTest(TestCase):
+    def setUp(self):
+        self.event = EventFactory()
+        self.bookings = BookingFactory.create_batch(10, event=self.event)
+        self.url = reverse("event_organizer_event_participants_export", kwargs={"pk": self.event.pk})
+        self.detail_url = reverse("event_organizer_event_detail", kwargs={"pk": self.event.pk})
+        self.user = self.event.owner
+
+    def test_export_participants_csv(self):
+        self.client.force_login(self.user)
+
+        # Is there the export link in detail view
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, self.url)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn("attachment; filename=", response["Content-Disposition"])
+
+        # Test CSV file content
+        content_lines = response.content.decode().split("\r\n")
+        self.assertEqual(content_lines[0], '"Prénom","Nom","Email","Aide","Commentaire","État"')
+        self.assertEqual(len(content_lines), 12)  # There is a blank line at the end
+
+
 class EventContributionCreateViewTest(TestCase):
     def setUp(self):
         self.event = EventFactory()

--- a/event/urls.py
+++ b/event/urls.py
@@ -7,6 +7,7 @@ from event.views.organizer import (
     OrganizerEventCreateView,
     OrganizerEventDetailView,
     OrganizerEventOrganizerAddView,
+    OrganizerEventParticipantsExportView,
     OrganizerEventUpdateView,
     OrganizerRegistrationAcceptView,
     OrganizerRegistrationDeclineView,
@@ -27,6 +28,11 @@ urlpatterns = [
     path("organizer/event/create", OrganizerEventCreateView.as_view(), name="event_organizer_event_create"),
     path("organizer/event/<int:pk>/detail/", OrganizerEventDetailView.as_view(), name="event_organizer_event_detail"),
     path("organizer/event/<int:pk>/update/", OrganizerEventUpdateView.as_view(), name="event_organizer_event_update"),
+    path(
+        "organizer/event/<int:pk>/participants/export",
+        OrganizerEventParticipantsExportView.as_view(),
+        name="event_organizer_event_participants_export",
+    ),
     path(
         "organizer/registration/<int:pk>/accept/",
         OrganizerRegistrationAcceptView.as_view(),

--- a/templates/event/organizer/event_detail.html
+++ b/templates/event/organizer/event_detail.html
@@ -91,29 +91,42 @@
                 </div>
               </div>
               <div id="tabpanel-405-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabindex="0">
-                <div class="fr-table fr-table--layout-fixed">
-                  <table>
-                    <caption>Liste des demandes de participation</caption>
-                    <thead>
-                      <tr>
-                        <th scope="col">Nom</th>
-                        <th scope="col">Email</th>
-                        <th scope="col">Statut</th>
-                        <th scope="col"></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {% for booking in bookings %}
-                        {% include "event/organizer/partials/booking_row.html" %}
-                      {% empty %}
-                        <tr>
-                          <td colspan="4">
-                            <p>Il n'y a pas encore de participant pour cette concertation...</p>
-                          </td>
-                        </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
+                <div class="fr-grid-row fr-grid-row--gutters fr-mb-1w">
+                  <div class="fr-col-md-9 fr-col-12">
+                    <h2>Liste des demandes de participation</h2>
+                  </div>
+                  <div class="fr-col-md-3 fr-col-12">
+                    <ul class="fr-btns-group fr-btns-group--inline-md fr-btns-group--right">
+                      <li>
+                        <a href="{% url 'event_organizer_event_participants_export' event.pk %}" class="fr-btn" target="_blank">Exporter (csv)</a>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="fr-col-12">
+                    <div class="fr-table fr-table--layout-fixed">
+                      <table>
+                        <thead>
+                          <tr>
+                            <th scope="col">Nom</th>
+                            <th scope="col">Email</th>
+                            <th scope="col">Statut</th>
+                            <th scope="col"></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {% for booking in bookings %}
+                            {% include "event/organizer/partials/booking_row.html" %}
+                          {% empty %}
+                            <tr>
+                              <td colspan="4">
+                                <p>Il n'y a pas encore de participant pour cette concertation...</p>
+                              </td>
+                            </tr>
+                          {% endfor %}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div id="tabpanel-406-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-406" tabindex="0">


### PR DESCRIPTION
Depuis la liste des participants à une concertation, le bouton "Exporter" permet de générer un fichier csv au format : 

"Prénom","Nom","Email","Aide","Commentaire","État"

![image](https://github.com/betagouv/CNR_orga/assets/17601807/12512fc4-46ec-43e9-b4dc-042190e988d4)
