### PR TITLE
Correction du bug des retours à la ligne coupée

### DIFF
--- a/templates/event/partials/contribution_card.html
+++ b/templates/event/partials/contribution_card.html
@@ -15,7 +15,7 @@
                     </li>
                     {% endif %}
                 </ul>
-                {{ contribution.description|linebreaksbr|truncatechars:120 }}
+                {{ contribution.description|truncatechars:120|linebreaksbr }}
                 {% if contribution.tags.count %}
                     <p class="fr-mt-2w">
                         #


### PR DESCRIPTION
Les balises `br` sont coupées si elles tombent dans au 120ème caractère..

En inversant les filtres, le problème est réglé.

![image](https://github.com/betagouv/CNR_orga/assets/17601807/65d994b6-6b6f-4e9d-9143-f04247281567)
